### PR TITLE
add ability to add more rows to ticker

### DIFF
--- a/jquery.newsTicker.js
+++ b/jquery.newsTicker.js
@@ -114,7 +114,9 @@
                         if(this.options.autostart)
                                 this.start();
                 },
-
+                add: function(content){
+                        this.$el.append($('<li>').html(content));
+                },
                 start: function() {
                         if (!this.state) {
                                 this.state = 1;


### PR DESCRIPTION
add ability to add more rows to ticker whilst it is running

can now call nt.newsTicker('add',"content of li"); 
to add items into the ticker whilst it is running
